### PR TITLE
Add takeProfitType and stopLossType

### DIFF
--- a/src/tradelocker/tradelocker_api.py
+++ b/src/tradelocker/tradelocker_api.py
@@ -1329,7 +1329,9 @@ class TLAPI:
             "tradableInstrumentId": str(instrument_id),
             "type": type_,
             "stopLoss": stop_loss,
+            "stopLossType": "absolute",
             "takeProfit": take_profit,
+            "takeProfitType": "absolute",
         }
 
         if position_netting:


### PR DESCRIPTION
When adding the `takeProfit` and `stopLoss`, you also need to specify `takeProfitType` and `stopLossType`.

Without these fields, the `takeProfit` and `stopLoss` values you pass in will be ignored and will not be applied to your order.

Hardcoding it to "absolute" for now. Already tested it, so that if you do omit `takeProfit` and `stopLoss`, passing in `takeProfitType` and `stopLossType` as "absolute" has no effect and order is created without issues.