### PR TITLE
chore: helper message when running tests

### DIFF
--- a/tests/test_tl_api.py
+++ b/tests/test_tl_api.py
@@ -18,6 +18,13 @@ from tradelocker.types import (
     PositionsColumns,
 )
 
+# check if the typeguard is installed and raise an explicit error if not
+try:
+    from typeguard import TypeCheckError
+except ImportError:
+    raise ImportError(
+        "====== To run tests, you should manually install typeguard using 'poetry run pip install typeguard' ====="
+    )
 
 LONG_BREAK = 2
 MID_BREAK = 1


### PR DESCRIPTION
We disabled installation of typeguard by default since it can cause problems with pyinstaller and similar tools, but require it for tests. This error message helps resolve that issue when running tests.