### PR TITLE
fix: price_history caching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "tradelocker"
-version = "0.56.1"
+version = "0.56.2"
 description = "Python client for TradeLocker's Trading API"
 authors = ["TradeLocker <admin@tradelocker.com>"]
 license = "MIT"


### PR DESCRIPTION
Memory (or disk) caching can only decorate a "pure" function, which always returns the same response for the same input parameters.

The function `get_price_history` isn't one due to having the `lookback_period` parameter, and due to allowing the `end_timestamp` to not be set, which defaults to `= now()`, and is thus different every time.

We thus move caching to a `_cacheable` function that only depends on the (defined) `_from` and `to` parameters, and is thus cacheable.